### PR TITLE
Eagerly load message template tags to reduce query chatter

### DIFF
--- a/src/main/kotlin/com/topfloor/messageplus/app/MessageTemplateService.kt
+++ b/src/main/kotlin/com/topfloor/messageplus/app/MessageTemplateService.kt
@@ -21,7 +21,7 @@ class MessageTemplateService(
 
     @Transactional(readOnly = true)
     fun list(q: String?): List<MessageTemplate> =
-        if (q.isNullOrBlank()) repo.findAll() else repo.findByTitleContainingIgnoreCase(q)
+        if (q.isNullOrBlank()) repo.findAllWithTags() else repo.findByTitleContainingIgnoreCase(q)
 
     @Transactional(readOnly = true)
     fun listByAllTagNames(tagNames: List<String>?, pageable: Pageable): Page<MessageTemplateDto> {

--- a/src/main/kotlin/com/topfloor/messageplus/domain/MessageTemplateRepository.kt
+++ b/src/main/kotlin/com/topfloor/messageplus/domain/MessageTemplateRepository.kt
@@ -3,12 +3,21 @@ package com.topfloor.messageplus.domain
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.domain.Specification
+import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
 interface MessageTemplateRepository : JpaRepository<MessageTemplate, UUID> {
+    @EntityGraph(attributePaths = ["tags"])
+    override fun findById(id: UUID): java.util.Optional<MessageTemplate>
+
+    @EntityGraph(attributePaths = ["tags"])
+    fun findAllWithTags(): List<MessageTemplate>
+
+    @EntityGraph(attributePaths = ["tags"])
     fun findAll(spec: Specification<MessageTemplate>?): List<MessageTemplate>
 
+    @EntityGraph(attributePaths = ["tags"])
     fun findAll(spec: Specification<MessageTemplate>?, pageable: Pageable): Page<MessageTemplate>
 
     fun findByTitleContainingIgnoreCase(q: String): List<MessageTemplate>


### PR DESCRIPTION
### Motivation
- Loading templates was causing per-template tag queries which slowed single-message edit views and list loads.
- The intent is to eagerly fetch the `tags` collection with templates to avoid N+1 query patterns and improve response times.

### Description
- Added `@EntityGraph(attributePaths = ["tags"])` to repository methods so `tags` are fetched with templates for `findById`, `findAll(spec)`, and `findAll(spec, pageable)`.
- Introduced a new repository method `findAllWithTags()` annotated with `@EntityGraph` for listing all templates with tags.
- Switched `MessageTemplateService.list(q)` to call `repo.findAllWithTags()` when no search query is provided so list views include tags in a single fetch.
- Added the necessary `EntityGraph` import in `MessageTemplateRepository.kt`.

### Testing
- No automated tests were run as part of this change.
- Local compilation or runtime checks were not performed during this edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69820929ca6c83208193d204629f2353)