### PR TITLE
Preserve message-template tag links on PUT updates

### DIFF
--- a/src/main/kotlin/com/topfloor/messageplus/app/MessageTemplateService.kt
+++ b/src/main/kotlin/com/topfloor/messageplus/app/MessageTemplateService.kt
@@ -54,21 +54,16 @@ class MessageTemplateService(
 
     @Transactional
     fun update(id: UUID, req: CreateUpdateMessageTemplateDto): MessageTemplate {
-        val template = get(id)
+        val template = repo.findById(id).orElseThrow { EntityNotFoundException("Template $id not found") }
         // prevent duplicate names on other rows
         if (!template.title.equals(req.title, ignoreCase = true) && repo.existsByTitleIgnoreCase(req.title)) {
             error("Message Template name already exists: ${req.title}")
         }
-        val updatedMessage =
-            MessageTemplate(
-                id = template.id,
-                title = req.title.trim(),
-                bodyPt = req.bodyPt,
-                bodyEn = req.bodyEn,
-                createdAt = template.createdAt,
-                updatedAt = Instant.now()
-            )
-        return repo.save(updatedMessage)
+        template.title = req.title.trim()
+        template.bodyPt = req.bodyPt
+        template.bodyEn = req.bodyEn
+        template.updatedAt = Instant.now()
+        return repo.save(template)
     }
 
     @Transactional

--- a/src/test/kotlin/com/topfloor/messageplus/app/MessageTemplateServiceTest.kt
+++ b/src/test/kotlin/com/topfloor/messageplus/app/MessageTemplateServiceTest.kt
@@ -1,0 +1,72 @@
+package com.topfloor.messageplus.app
+
+import com.topfloor.messageplus.api.dto.CreateUpdateMessageTemplateDto
+import com.topfloor.messageplus.domain.MessageTemplate
+import com.topfloor.messageplus.domain.MessageTemplateRepository
+import com.topfloor.messageplus.domain.Tag
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import jakarta.persistence.EntityNotFoundException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.util.Optional
+import java.util.UUID
+
+class MessageTemplateServiceTest {
+
+    private val repo = mockk<MessageTemplateRepository>()
+    private val service = MessageTemplateService(repo)
+
+    @Test
+    fun `update preserves existing tag links`() {
+        val id = UUID.randomUUID()
+        val vipTag = Tag(id = UUID.randomUUID(), name = "vip")
+        val template = MessageTemplate(
+            id = id,
+            title = "Initial title",
+            bodyPt = "Texto",
+            bodyEn = "Text"
+        )
+        template.tags.add(vipTag)
+
+        every { repo.findById(id) } returns Optional.of(template)
+        every { repo.save(any()) } answers { firstArg() }
+
+        val updated = service.update(
+            id = id,
+            req = CreateUpdateMessageTemplateDto(
+                title = "Updated title",
+                bodyPt = "Novo texto",
+                bodyEn = "New text"
+            )
+        )
+
+        assertSame(template, updated)
+        assertEquals(setOf(vipTag), updated.tags)
+
+        val savedTemplate = slot<MessageTemplate>()
+        verify { repo.save(capture(savedTemplate)) }
+        assertEquals(setOf(vipTag), savedTemplate.captured.tags)
+    }
+
+    @Test
+    fun `update throws when template does not exist`() {
+        val id = UUID.randomUUID()
+        every { repo.findById(id) } returns Optional.empty()
+
+        assertThrows(EntityNotFoundException::class.java) {
+            service.update(
+                id = id,
+                req = CreateUpdateMessageTemplateDto(
+                    title = "Updated title",
+                    bodyPt = "Novo texto",
+                    bodyEn = "New text"
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- PUT update rebuilt a new `MessageTemplate` instance from request data which would drop existing many-to-many `tags` links, conflicting with the expectation that tag linking/unlinking is managed via dedicated endpoints. 
- Change update semantics to modify the managed entity in place so existing associations are preserved.

### Description
- Changed `MessageTemplateService.update` to load the managed entity via `repo.findById(id).orElseThrow(...)` and mutate its fields (`title`, `bodyPt`, `bodyEn`, `updatedAt`) instead of constructing a new `MessageTemplate` object. 
- Kept the duplicate-title validation intact (`existsByTitleIgnoreCase`) and preserved the existing `tags` collection by saving the mutated entity. 
- Added `MessageTemplateServiceTest` with tests that assert `update` preserves pre-existing tag links and that updating a non-existent template throws `EntityNotFoundException`.

### Testing
- Added unit tests in `src/test/kotlin/com/topfloor/messageplus/app/MessageTemplateServiceTest.kt` covering tag preservation and not-found behavior. 
- Attempted to run `./gradlew test --tests "com.topfloor.messageplus.app.MessageTemplateServiceTest"`, but the build failed in this environment before test execution due to a Kotlin/Gradle Java version parsing issue (`IllegalArgumentException: 25.0.1`), so tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cecba62a008320acfa7a11327bcd46)