### PR TITLE
MessageTemplateService.update now returns DTO and preserves tag links; add unit tests

### DIFF
--- a/src/main/kotlin/com/topfloor/messageplus/api/MessageTemplateController.kt
+++ b/src/main/kotlin/com/topfloor/messageplus/api/MessageTemplateController.kt
@@ -61,7 +61,7 @@ class MessageTemplateController(
 
     @PutMapping("/{id}")
     fun update(@PathVariable id: UUID, @RequestBody req: CreateUpdateMessageTemplateDto): MessageTemplateDto =
-        service.update(id, req).toDto()
+        service.update(id, req)
 
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/src/main/kotlin/com/topfloor/messageplus/app/MessageTemplateService.kt
+++ b/src/main/kotlin/com/topfloor/messageplus/app/MessageTemplateService.kt
@@ -53,22 +53,17 @@ class MessageTemplateService(
     }
 
     @Transactional
-    fun update(id: UUID, req: CreateUpdateMessageTemplateDto): MessageTemplate {
-        val template = get(id)
+    fun update(id: UUID, req: CreateUpdateMessageTemplateDto): MessageTemplateDto {
+        val template = repo.findById(id).orElseThrow { EntityNotFoundException("Template $id not found") }
         // prevent duplicate names on other rows
         if (!template.title.equals(req.title, ignoreCase = true) && repo.existsByTitleIgnoreCase(req.title)) {
             error("Message Template name already exists: ${req.title}")
         }
-        val updatedMessage =
-            MessageTemplate(
-                id = template.id,
-                title = req.title.trim(),
-                bodyPt = req.bodyPt,
-                bodyEn = req.bodyEn,
-                createdAt = template.createdAt,
-                updatedAt = Instant.now()
-            )
-        return repo.save(updatedMessage)
+        template.title = req.title.trim()
+        template.bodyPt = req.bodyPt
+        template.bodyEn = req.bodyEn
+        template.updatedAt = Instant.now()
+        return repo.save(template).toDto()
     }
 
     @Transactional

--- a/src/test/kotlin/com/topfloor/messageplus/app/MessageTemplateServiceTest.kt
+++ b/src/test/kotlin/com/topfloor/messageplus/app/MessageTemplateServiceTest.kt
@@ -1,0 +1,70 @@
+package com.topfloor.messageplus.app
+
+import com.topfloor.messageplus.api.dto.CreateUpdateMessageTemplateDto
+import com.topfloor.messageplus.domain.MessageTemplate
+import com.topfloor.messageplus.domain.MessageTemplateRepository
+import com.topfloor.messageplus.domain.Tag
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import jakarta.persistence.EntityNotFoundException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.util.Optional
+import java.util.UUID
+
+class MessageTemplateServiceTest {
+
+    private val repo = mockk<MessageTemplateRepository>()
+    private val service = MessageTemplateService(repo)
+
+    @Test
+    fun `update preserves existing tag links`() {
+        val id = UUID.randomUUID()
+        val vipTag = Tag(id = UUID.randomUUID(), name = "vip")
+        val template = MessageTemplate(
+            id = id,
+            title = "Initial title",
+            bodyPt = "Texto",
+            bodyEn = "Text"
+        )
+        template.tags.add(vipTag)
+
+        every { repo.findById(id) } returns Optional.of(template)
+        every { repo.save(any()) } answers { firstArg() }
+
+        val updated = service.update(
+            id = id,
+            req = CreateUpdateMessageTemplateDto(
+                title = "Updated title",
+                bodyPt = "Novo texto",
+                bodyEn = "New text"
+            )
+        )
+
+        assertEquals(listOf("vip"), updated.tags.map { it.name })
+
+        val savedTemplate = slot<MessageTemplate>()
+        verify { repo.save(capture(savedTemplate)) }
+        assertEquals(setOf(vipTag), savedTemplate.captured.tags)
+    }
+
+    @Test
+    fun `update throws when template does not exist`() {
+        val id = UUID.randomUUID()
+        every { repo.findById(id) } returns Optional.empty()
+
+        assertThrows(EntityNotFoundException::class.java) {
+            service.update(
+                id = id,
+                req = CreateUpdateMessageTemplateDto(
+                    title = "Updated title",
+                    bodyPt = "Novo texto",
+                    bodyEn = "New text"
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure the `update` flow returns a DTO directly from the service so the controller does not need to call `.toDto()` itself.
- Fix updating logic to mutate and save the existing `MessageTemplate` entity so existing associations (like tags) are preserved.
- Add unit tests to validate tag preservation and not-found behavior for `update`.

### Description
- Change `MessageTemplateService.update` signature to return `MessageTemplateDto` and fetch the entity with `repo.findById` so the existing entity is mutated and saved rather than constructing a new instance.
- Update the entity fields (`title`, `bodyPt`, `bodyEn`, `updatedAt`) in place and call `repo.save(template).toDto()` to return the DTO.
- Adjust `MessageTemplateController.update` to accept the DTO returned by the service and remove the redundant `.toDto()` call.
- Add `MessageTemplateServiceTest` with tests that assert tag links are preserved after `update` and that `update` throws `EntityNotFoundException` when the template does not exist.

### Testing
- Added unit tests in `MessageTemplateServiceTest` covering tag preservation and not-found behavior for `update` and ran them as part of the test suite, and they passed.
- Existing repository interactions are mocked with `mockk` in the new tests and the `repo.save` behavior was verified to preserve the `tags` set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cecba62a008320acfa7a11327bcd46)